### PR TITLE
Add pacman executables for auto updater tests

### DIFF
--- a/electron-builder.js
+++ b/electron-builder.js
@@ -57,7 +57,7 @@ const options = {
 
         },
 
-        target: ["deb"] //, "AppImage", "rpm"]
+        target: ["deb", "AppImage", "rpm", "pacman"]
     },
 };
 


### PR DESCRIPTION
- Updating linux targets to include pacman for autoupdate tests on the electron-builder repo
- Noticed that .AppImage and .rpm were commented out so I checked the git blame and it seems it was for temporary testing. So, uncommented that as well.

Related PRs: https://github.com/electron-userland/electron-builder/pull/8394